### PR TITLE
docs: remove deprecated Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 Image De-duplicator
 ===================
 
-[![Go Report Card](https://goreportcard.com/badge/donatj/imgdedup)](https://goreportcard.com/report/donatj/imgdedup)
 [![CI](https://github.com/donatj/imgdedup/actions/workflows/ci.yml/badge.svg)](https://github.com/donatj/imgdedup/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/donatj/imgdedup.svg)](https://pkg.go.dev/github.com/donatj/imgdedup)
 


### PR DESCRIPTION
Removes the obsolete goreportcard.com badge from the README.